### PR TITLE
WIP:bugfix/ModuleCrashWhenEmpty

### DIFF
--- a/scripts/runtime/msai_runtime.py
+++ b/scripts/runtime/msai_runtime.py
@@ -443,6 +443,9 @@ class MiaoshouRuntime(object):
         except Exception as e:
             dst = self.prelude.no_preview_img
 
+        if self.my_model_set is None:
+            return None
+
         for model in self.my_model_set:
             match = False
 


### PR DESCRIPTION
# issue 
The tab is not present and I got an error about `my_model_set ` being a `NoneType `.
Note sure what cause the NoneType but I just return when it happened.

# Solution
I return if the variable is none, but not sure if it work correctly.



